### PR TITLE
docs: include metadata for sprint2 analysis

### DIFF
--- a/0_5_vulns/_template.md
+++ b/0_5_vulns/_template.md
@@ -8,6 +8,16 @@ Name of the author(s) who have contributed to documenting this vulnerability.
 
 A brief description of the vulnerability that includes its potential effects such as system compromises, data breaches, or other security concerns.
 
+**Labels/Tags:** (**Mandatory**)
+
+A bullet-separated list of labels (AKA tags) that can be used to distinguish associated terminology or phrases to the description of your vulnerability. If !>1 label is available based on your submission, ensure this is entered on at least one bullet point.
+
+> _A common example: Prompt Injection" can also be also described or referred to as "Prompt Hacking", "Jailbreaking" etc_
+
+- Label: ""
+- Label: ""
+- Label: ""
+
 **Common Examples of Vulnerability:**
 
 1. Example 1: Specific instance or type of this vulnerability.


### PR DESCRIPTION
**Background:**

My reasoning is, that because we are still in early adoption phases and hence the reason for this project, many vulnerabilities and exploits or PoC's are using different terminology adapted from traditional API Security with an LLM spice on the side. This has also been spread further by media and using "buzzwords" as such.

**TL;DR:**

The simple idea and reason for my formatting is to allow:

1. Researchers to provide additional content to their submission when there are multiple associated terminologies for their submission and prevent's a "clunky" title or clear description.
2. Allow the OWASP sprint 2 team to perform (`""Label: "X" "Label: "Y""`)-_style_ searching when performing the filtering and analysis phase to reduce fatigue of duplicates and enhance efficiency of task.