### PR TITLE
chore: start a working codeowners in progress

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,33 @@
+## Explicit Match Any:
+*   @GangGreenTemperTatum
+
+# Shared Community Files and Areas:
+# TBC
+
+## Either Ads or Steve can approve changes to CODEOWNERS:
+CODEOWNERS @GangGreenTemperTatum @virtualsteve-star
+
+# Top 10 Vulnerabilities: (www-project-top-10-for-large-language-model-applications/1_1_vulns/)
+## LLM01:
+# TBC PromptInjection.md @
+## LLM02:
+# TBC InsecureOutputHandling.md @
+## LLM03:
+TrainingDataPoisoning.md @GangGreenTemperTatum
+## LLM04:
+ModelDoS.md @kenhuangus
+## LLM05:
+SupplyChainVulnerabilities.md @jsotiro
+## LLM06:
+SensitiveInformationDisclosure.md @GangGreenTemperTatum
+## LLM07:
+InsecurePluginDesign.md @jsotiro
+## LLM08:
+ExcessiveAgency.md @rot169
+## LLM09:
+Overreliance.md @virtualsteve-star
+## LLM10:
+ModelTheft.md @GangGreenTemperTatum
+
+## Template:
+_template.md @rossja @mkfnch


### PR DESCRIPTION
As per [here](https://owasp.slack.com/archives/C05956H7R8R/p1692210090951119?thread_ts=1692208698.042749&cid=C05956H7R8R), taking ownership for this I would like to start a `CODEOWNERS` to establish, delegate and assign roles to the LLMTop10 Core Team as we move forward with the project
Two top 10 vulnerabilities are still awaiting assigned individual owners as per [here](https://owasp.slack.com/archives/C05956H7R8R/p1692393538758939)
So far, this will allow assigned roles to approve PR's for their specific individual owned vulnerabilities including Mike and Jason on styling