### PR TITLE
docs: publish build to owasp project site for 1_1

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,7 +1,8 @@
 ### Top 10 for Large Language Model Applications Information
 * [Incubator Project](https://owasp.org/projects/)
-* [Version 1.0.1](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0_1.pdf) 
-* [Version 1.0.0](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0.pdf) (archived) 
+* [Version 1.1.0](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_1.pdf)
+* [Version 1.0.1](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0_1.pdf) (archived)
+* [Version 1.0.0](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0.pdf) (archived)
 * [Version 0.9.0](assets/PDF/OWASP-Top-10-for-LLMs-2023-v09.pdf) (archived)
 * [Version 0.5.0](assets/PDF/OWASP-Top-10-for-LLMs-2023-v05.pdf) (archived)
 * [Version 0.1.0](Archive/0_1_vulns/) (archived)


### PR DESCRIPTION
- Approved by @virtualsteve-star [here](https://owasp.slack.com/archives/C060XQ4MUJJ/p1697596821163569)
- Publish the `v1_1` via the `info.md` to initiate the build to the [OWASP project site](https://owasp.org/www-project-top-10-for-large-language-model-applications/)