### PR TITLE
chore: trigger build for updated index 1_1

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,9 +11,9 @@ pitch: Aims to educate developers, designers, architects, managers, and organiza
 
 The OWASP Top 10 for Large Language Model Applications project aims to educate developers, designers, architects, managers, and organizations about the potential security risks when deploying and managing Large Language Models (LLMs). The project provides a list of the top 10 most critical vulnerabilities often seen in LLM applications, highlighting their potential impact, ease of exploitation, and prevalence in real-world applications. Examples of vulnerabilities include prompt injections, data leakage, inadequate sandboxing, and unauthorized code execution, among others. The goal is to raise awareness of these vulnerabilities, suggest remediation strategies, and ultimately improve the security posture of LLM applications. You can read our [group charter](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/wiki/Charter) for more information
 
-Review the official 1.0.1 release ([Full Version](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0_1.pdf) or [Short Slides](assets/PDF/OWASP-Top-10-for-LLMs-2023-slides-v1_0_1.pdf)) to understand work that has been done to date.
+Review the official 1.1 release ([Full Version](assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_1.pdf) or [Short Slides](assets/PDF/OWASP-Top-10-for-LLMs-2023-slides-v1_1.pdf)) to understand work that has been done to date.
 
-This initiative is community-driven and encourages participation and contributions from all interested parties. 
+This initiative is community-driven and encourages participation and contributions from all interested parties.
 
 * We have a working group channel on the [OWASP Slack](https://owasp.org/slack/invite), so please sign up and then join us on the #project-top10-for-llm channel.
 * The working group is collaborating on our [wiki](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/wiki)


### PR DESCRIPTION
- #221 published the build to the [OWASP project site](https://owasp.org/www-project-top-10-for-large-language-model-applications/)

![image](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/assets/104169244/778c37d2-42f4-4cfd-816b-d68bb59c8a54)

- However, the `index` requires updating:

```
Review the official 1.0.1 release ([Full Version](https://owasp.org/www-project-top-10-for-large-language-model-applications/assets/PDF/OWASP-Top-10-for-LLMs-2023-v1_0_1.pdf) or [Short Slides](https://owasp.org/www-project-top-10-for-large-language-model-applications/assets/PDF/OWASP-Top-10-for-LLMs-2023-slides-v1_0_1.pdf)) to understand work that has been done to date.
```