### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/Archive/MockPressRelease.md
+++ b/Archive/MockPressRelease.md
@@ -14,7 +14,7 @@ Remember, this is a tool for us - a guiding star - not a binding prediction. It 
 Introducing the OWASP Top 10 for LLM Applications Project: Ensuring the Security and Safety  of Applications Powered by Large Language Models like GPT and Google's BERT
 
 ## San Francisco, CA – July 20, 2023
-Today, the Open Web Application Security Project (OWASP) is pleased to announce the launch of the OWASP Top 10 for Large Language Model (LLM) Applications project.  The list encompassess the most important security vulnerabilities as they relate to applications being built using large language models.   This initiative focuses on providing valuable guidance to developers who are building applications leveraging LLM technologies, such as OpenAI's GPT Series and Google's Bard, which are causing increased interest in the field of artificial intelligence.
+Today, the Open Worldwide Application Security Project (OWASP) is pleased to announce the launch of the OWASP Top 10 for Large Language Model (LLM) Applications project.  The list encompassess the most important security vulnerabilities as they relate to applications being built using large language models.   This initiative focuses on providing valuable guidance to developers who are building applications leveraging LLM technologies, such as OpenAI's GPT Series and Google's Bard, which are causing increased interest in the field of artificial intelligence.
 
 "Enterprises are increasingly using Large Language Models for a wide variety of applications, and ensuring the security of these applications is paramount," said Steve Wilson, Project Leader for OWASP and cybersecurity expert at Contrast Security. "Our goal with this project is to provide a reliable and comprehensive resource for developers to create secure applications embedding artificial intelligence."
 
@@ -28,7 +28,7 @@ This project seeks to highlight the crucial security risks associated with using
 For more information, please visit the project's GitHub repository at: (repository link)
 
 ## About OWASP
-The Open Web Application Security Project (OWASP) is a nonprofit foundation that works to improve the security of software. Through community-led open source software projects, hundreds of local chapters worldwide, tens of thousands of members, and leading educational and training conferences, the OWASP Foundation is the source for developers and technologists to secure the web.
+The Open Worldwide Application Security Project (OWASP) is a nonprofit foundation that works to improve the security of software. Through community-led open source software projects, hundreds of local chapters worldwide, tens of thousands of members, and leading educational and training conferences, the OWASP Foundation is the source for developers and technologists to secure the web.
 
 ### Press Contact
 Name, Title

--- a/initiatives/data_gathering/literature/README.md
+++ b/initiatives/data_gathering/literature/README.md
@@ -1,6 +1,6 @@
 # OWASP Top 10 for LLM - Literature Review
 
-This repository is dedicated to the literature review of the OWASP (Open Web Application Security Project) Top 10 vulnerabilities as they pertain to Language Learning Models (LLMs). Our goal is to collect, categorize, and analyze academic papers, articles, and any form of literature that addresses these vulnerabilities in the context of LLMs.
+This repository is dedicated to the literature review of the OWASP (Open Worldwide Application Security Project) Top 10 vulnerabilities as they pertain to Language Learning Models (LLMs). Our goal is to collect, categorize, and analyze academic papers, articles, and any form of literature that addresses these vulnerabilities in the context of LLMs.
 
 ## Project Description
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)