### PR TITLE
LLM03: add scenario for compromised build pipeline producing tampered…

### DIFF
--- a/2_0_vulns/LLM03_SupplyChain.md
+++ b/2_0_vulns/LLM03_SupplyChain.md
@@ -120,6 +120,10 @@ A simple threat model can be found [here](https://github.com/jsotiro/ThreatModel
 
   An LLM operator changes its T&Cs and Privacy Policy to require an explicit opt out from using application data for model training, leading to the memorization of sensitive data.
 
+#### Scenario #14: Compromised Build Pipeline for Model Artifacts
+
+  An attacker compromises the CI/CD pipeline an organization uses to fine-tune and publish an LLM. For example, through a malicious GitHub Actions dependency, a stolen artifact registry credential, or a tampered build-time secret. During the next training or packaging run, the pipeline produces a tampered model artifact containing a backdoor or biased behavior. Because the artifact is built and signed by the organization's own release infrastructure, it passes downstream provenance checks, internal attestation, and supply-chain scanners that only flag externally sourced components. Similar build-time substitution attacks have affected traditional software supply chains through incidents like the xz-utils backdoor and the Codecov breach; the same attack surface exists wherever model artifacts are produced by automated pipelines without model-specific integrity controls such as reproducible builds, transparency logs, or post-build behavioral evaluation.
+
 ### Reference Links
 
 1. [PoisonGPT: How we hid a lobotomized LLM on Hugging Face to spread fake news](https://blog.mithrilsecurity.io/poisongpt-how-we-hid-a-lobotomized-llm-on-hugging-face-to-spread-fake-news)


### PR DESCRIPTION
## Summary

Adds a new attack scenario (Scenario #14) to LLM03 covering compromise of an organization's own CI/CD pipeline producing tampered model artifacts at build time.

## Motivation

The existing 13 scenarios in LLM03 all treat the supply chain risk as originating from an external component (third-party package, public model, upstream dataset, collaborative merge service, etc.). None cover the case where the organization's own build pipeline is compromised and produces a tampered artifact that passes provenance and attestation checks precisely because it was signed by the trusted internal release infrastructure.

This attack class has well-known analogues in traditional software supply chains (xz-utils, Codecov, SolarWinds). The equivalent attack surface exists for ML pipelines wherever model artifacts are built, signed, and deployed automatically without model-specific integrity controls. Given the growing use of internal fine-tuning pipelines and CI/CD-driven model releases, this scenario seems worth calling out explicitly in the supply chain threat model.

## Scope

- One new scenario appended as Scenario #14. No other changes.
- Matches the existing scenario format and length.
- Happy to expand into a matching entry in the Prevention and Mitigation Strategies section if reviewers want that in this PR or as a follow-up.