### PR TITLE
LLM08: add scenario for residual embeddings after source data deletion

### DIFF
--- a/2_0_vulns/LLM08_VectorAndEmbeddingWeaknesses.md
+++ b/2_0_vulns/LLM08_VectorAndEmbeddingWeaknesses.md
@@ -78,6 +78,14 @@ Retrieval Augmented Generation (RAG) is a model adaptation technique that enhanc
 
   The impact of RAG on the foundational model's behavior should be monitored and evaluated, with adjustments to the augmentation process to maintain desired qualities like empathy(Ref #8).
 
+#### Scenario #4: Residual Embeddings After Source Data Deletion
+
+  An organization deletes a set of source documents from its primary data store in response to a data subject deletion request or retention policy, but the corresponding embeddings remain in the RAG vector store because the deletion workflow targets only the canonical content repository. An attacker with access to the vector store- through misconfigured access controls, a compromised read-only service account, or an exposed backup snapshot- applies embedding inversion techniques to recover substantial portions of the original document content from the residual embeddings. The organization believes the data is deleted and has reported it as such for compliance purposes, but the content remains recoverable for as long as the embeddings persist.
+
+#### Mitigation
+
+  Deletion workflows should propagate to all derived stores including vector databases, embedding caches, and backup snapshots. Treat embeddings as equivalent in sensitivity to the source content they were derived from. Where deletion cannot be guaranteed, for example on retained backups, document residual exposure explicitly in data retention and compliance records rather than reporting the data as fully deleted.
+
 ### Reference Links
 
 1. [Augmenting a Large Language Model with Retrieval-Augmented Generation and Fine-tuning](https://learn.microsoft.com/en-us/azure/developer/ai/augment-llm-rag-fine-tuning)


### PR DESCRIPTION
# LLM08: Add scenario for residual embeddings after source data deletion

**Key Changes:**

- [x] New attack scenario (Scenario #4) in LLM08 covering residual vector embeddings that persist after source data deletion
- [x] Matching Mitigation sub-block following the existing LLM08 format

**Added:**

- [x] Scenario #4: Residual Embeddings After Source Data Deletion
- [x] Mitigation guidance for deletion propagation across derived stores (vector databases, embedding caches, backup snapshots)

---

## Motivation

LLM08 already establishes that embeddings can be inverted to recover substantial portions of source content (Common Examples #3, References #3 and #4). However, none of the existing scenarios address the failure mode where organizations believe they have deleted data, and have reported that deletion for compliance purposes, while the corresponding embeddings remain recoverable in the vector store.

This is increasingly relevant as RAG pipelines ingest from primary data stores governed by retention policies, data subject requests, and regulatory deletion requirements (GDPR, CCPA, internal retention schedules). Deletion workflows that target only the canonical content repository leave residual exposure in vector databases, embedding caches, and snapshots that compliance teams may not be aware of.

## Scope

One new scenario appended as Scenario #4 with matching Mitigation sub-block. No other changes.