### PR TITLE
feat: add MCP-specific attack mechanics to LLM01 and LLM06 (closes #806)

### DIFF
--- a/2_0_vulns/LLM01_PromptInjection.md
+++ b/2_0_vulns/LLM01_PromptInjection.md
@@ -29,6 +29,8 @@ The severity and nature of the impact of a successful prompt injection attack ca
 
 The rise of multimodal AI, which processes multiple data types simultaneously, introduces unique prompt injection risks. Malicious actors could exploit interactions between modalities, such as hiding instructions in images that accompany benign text. The complexity of these systems expands the attack surface. Multimodal models may also be susceptible to novel cross-modal attacks that are difficult to detect and mitigate with current techniques. Robust multimodal-specific defenses are an important area for further research and development.
 
+External sources also include the metadata of tools and extensions made available to the model. In protocols such as the Model Context Protocol (MCP), a client enumerates the connected tools and loads their descriptions into the model's context at session initialization, before the user submits a prompt. The model parses a tool description as it parses any other instruction, yet that description is not ordinarily shown to the user. When a tool originates from a server the user approved earlier, its description becomes an indirect injection channel that operates outside the user's view and outside the boundary of user-supplied input. The model has no inherent means of distinguishing a legitimate functional instruction in a tool description from an adversarial one; it processes both as context.
+
 ### Prevention and Mitigation Strategies
 
 Prompt injection vulnerabilities are possible due to the nature of generative AI. Given the stochastic influence at the heart of the way models work, it is unclear if there are fool-proof methods of prevention for prompt injection. However, the following measures can mitigate the impact of prompt injections:
@@ -55,7 +57,7 @@ Prompt injection vulnerabilities are possible due to the nature of generative AI
 
 #### 6. Segregate and identify external content
 
-  Separate and clearly denote untrusted content to limit its influence on user prompts.
+  Separate and clearly denote untrusted content to limit its influence on user prompts. Treat the descriptions and metadata of connected tools as untrusted external content: verify them against signed tool manifests at load time, and validate that each tool's stated description matches its runtime behavior.
 
 #### 7. Conduct adversarial testing and attack simulations
 
@@ -99,6 +101,14 @@ Prompt injection vulnerabilities are possible due to the nature of generative AI
 
   An attacker uses multiple languages or encodes malicious instructions (e.g., using Base64 or emojis) to evade filters and manipulate the LLM's behavior.
 
+#### Scenario #10: Tool Description Poisoning
+
+  An attacker publishes an MCP server whose tool description embeds hidden instructions that, once the user connects the server, direct the model to read local credential files and transmit them to an attacker-controlled endpoint, exfiltrating sensitive credentials without the user's knowledge.
+
+#### Scenario #11: Cross-Server Tool Shadowing
+
+  An attacker connects a malicious MCP server alongside a trusted one and registers a tool whose description shadows the trusted server's tools, redefining how the agent uses them so that the agent itself, not the malicious server, invokes those tools to exfiltrate the data they can access.
+
 ### Reference Links
 
 1. [ChatGPT Plugin Vulnerabilities - Chat with Code](https://embracethered.com/blog/posts/2023/chatgpt-plugin-vulns-chat-with-code/) **Embrace the Red**
@@ -115,6 +125,10 @@ Prompt injection vulnerabilities are possible due to the nature of generative AI
 12. [Exploiting Programmatic Behavior of LLMs: Dual-Use Through Standard Security Attacks](https://ieeexplore.ieee.org/document/10579515)
 13. [Universal and Transferable Adversarial Attacks on Aligned Language Models (arxiv.org)](https://arxiv.org/abs/2307.15043)
 14. [From ChatGPT to ThreatGPT: Impact of Generative AI in Cybersecurity and Privacy (arxiv.org)](https://arxiv.org/abs/2307.00691)
+15. [MCP Security Notification: Tool Poisoning Attacks](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks) **Invariant Labs**
+16. [WhatsApp MCP Exploited: Exfiltrating Your Message History via MCP](https://invariantlabs.ai/blog/whatsapp-mcp-exploited) **Invariant Labs**
+17. [A Practical Guide for Secure MCP Server Development](https://genai.owasp.org/resource/a-practical-guide-for-secure-mcp-server-development/) **OWASP GenAI Security Project**
+18. [Model Context Protocol prompt injection](https://simonwillison.net/2025/Apr/9/mcp-prompt-injection/) **Simon Willison**
 
 ### Related Frameworks and Taxonomies
 

--- a/2_0_vulns/LLM06_ExcessiveAgency.md
+++ b/2_0_vulns/LLM06_ExcessiveAgency.md
@@ -43,7 +43,7 @@ Note: Excessive Agency differs from Insecure Output Handling which is concerned 
 
 #### 6. Excessive Autonomy
 
-  An LLM-based application or extension fails to independently verify and approve high-impact actions. E.g., an extension that allows a user's documents to be deleted performs deletions without any confirmation from the user.
+  An LLM-based application or extension fails to independently verify and approve high-impact actions. E.g., an extension that allows a user's documents to be deleted performs deletions without any confirmation from the user. An LLM-based application grants the agent autonomy to invoke a tool based on an authorization made at approval time, but does not re-validate at execution that the tool still matches what was authorized, so a tool modified or shadowed after approval runs under stale authorization. For example, the configuration of a previously approved tool is altered in a shared repository, or another connected tool redefines how the agent uses it, and the agent invokes the changed tool without rechecking it against the original approval.
 
 ### Prevention and Mitigation Strategies
 
@@ -75,7 +75,7 @@ The following actions can prevent Excessive Agency:
 
 #### 7. Complete mediation
 
-  Implement authorization in downstream systems rather than relying on an LLM to decide if an action is allowed or not. Enforce the complete mediation principle so that all requests made to downstream systems via extensions are validated against security policies.
+  Implement authorization in downstream systems rather than relying on an LLM to decide if an action is allowed or not. Enforce the complete mediation principle so that all requests made to downstream systems via extensions are validated against security policies. Bind authorization to execution by re-validating the resolved invocation (tool identity, parameters, and version) against the originally authorized context at the tool boundary, and reject any call that no longer matches.
 
 #### 8. Sanitise LLM inputs and outputs
 
@@ -96,6 +96,8 @@ An LLM-based personal assistant app is granted access to an individual’s mailb
 
 Alternatively, the damage caused could be reduced by implementing rate limiting on the mail-sending interface.
 
+An agentic system connects to several MCP servers whose tools the user approved at setup, and the agent is free to invoke them without re-checking each call against that approval. In one case, the configuration of an approved tool is modified after approval, for example by editing it in a shared repository, and the agent executes the altered tool under the original trust, performing actions the user never authorized. In another, a co-loaded malicious server shadows a trusted tool, and the agent invokes it under the trusted tool's standing authorization even though its behavior no longer matches what was approved, executing the attacker's action with the trusted tool's privileges.
+
 ### Reference Links
 
 1. [Slack AI data exfil from private channels](https://promptarmor.substack.com/p/slack-ai-data-exfiltration-from-private): **PromptArmor**
@@ -104,3 +106,6 @@ Alternatively, the damage caused could be reduced by implementing rate limiting 
 4. [NeMo-Guardrails: Interface guidelines](https://github.com/NVIDIA/NeMo-Guardrails/blob/main/docs/security/guidelines.md): **NVIDIA Github**
 5. [Simon Willison: Dual LLM Pattern](https://simonwillison.net/2023/Apr/25/dual-llm-pattern/): **Simon Willison**
 6. [Sandboxing Agentic AI Workflows with WebAssembly](https://developer.nvidia.com/blog/sandboxing-agentic-ai-workflows-with-webassembly/) **NVIDIA, Joe Lucas**
+7. [MCPoison (CVE-2025-54136): persistent code execution via a modified, previously-trusted MCP configuration](https://nvd.nist.gov/vuln/detail/CVE-2025-54136): **NIST NVD** (research disclosure: [Check Point Research](https://research.checkpoint.com/2025/cursor-vulnerability-mcpoison/))
+8. [WhatsApp MCP Exploited: Exfiltrating Your Message History via MCP](https://invariantlabs.ai/blog/whatsapp-mcp-exploited): **Invariant Labs**
+9. [A Practical Guide for Secure MCP Server Development](https://genai.owasp.org/resource/a-practical-guide-for-secure-mcp-server-development/): **OWASP GenAI Security Project**


### PR DESCRIPTION
Closes #806

Adds MCP-specific indirect injection mechanics to LLM01 and LLM06

**LLM01 additions:**
- Extends Indirect Prompt Injections to cover tool metadata as an 
  injection channel (tool descriptions loaded at session init, before 
  user interaction)
- Scenario #10: Tool Description Poisoning (Invariant Labs, Apr 2025)
- Scenario #11: Cross-Server Tool Shadowing (Invariant Labs, Apr 2025)
- Prevention #6 extended: treat tool descriptions as untrusted 
  external content

**LLM06 additions:**
- Common Example #6 extended: authorization granted at approval time 
  not re-validated at execution
- Prevention #7 extended: bind authorization to execution at the 
  tool boundary
- New scenario: agentic trust-boundary failure via rug pull and 
  cross-server shadowing (CVE-2025-54136, Invariant Labs)

**Sources verified:**
- Invariant Labs, Tool Poisoning Attacks, 2025-04-01
- Invariant Labs, WhatsApp MCP Exploited, 2025-04-07
- CVE-2025-54136 (MCPoison), Check Point / NIST NVD, 2025-08-05, CVSS 8.8
- OWASP Secure MCP Server Development Guide, Feb 2026