### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ This project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 
 <picture>
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date&theme=dark"
+    srcset="https://star-history.dera.page/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date&theme=dark"
   />
   <source
     media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date"
+    srcset="https://star-history.dera.page/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date"
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date"
+    src="https://star-history.dera.page/svg?repos=OWASP/www-project-top-10-for-large-language-model-applications&type=Date"
   />
 </picture>


### PR DESCRIPTION
## Summary

The star history chart in the README is currently broken and does not render, so visitors can no longer see the project's activity at a glance.

This pull request updates the chart to a working source so it displays correctly again.

Fixes the project page as part of the archive cleanup.